### PR TITLE
rx: beet plugin support

### DIFF
--- a/allay/__init__.py
+++ b/allay/__init__.py
@@ -1,4 +1,13 @@
 from .parser import Parser
-from .plugin import beet_default
 
-__all__ = ['Parser', 'beet_default']
+__all__ = ["Parser"]
+
+# Lets try to import beet if it exists
+# This allows it to stay as an optional dep
+try:
+    import beet
+    from .plugin import beet_default
+
+    __all__.append("beet_default")
+except ImportError:
+    pass

--- a/allay/__init__.py
+++ b/allay/__init__.py
@@ -1,1 +1,4 @@
-from allay.parser import Parser
+from .parser import Parser
+from .plugin import beet_default
+
+__all__ = ['Parser', 'beet_default']

--- a/allay/parser.py
+++ b/allay/parser.py
@@ -18,15 +18,12 @@ class Parser:
         Returns:
             str: The text-component
         """
-        try:
-            if indent:
-                return json.dumps(
-                    self.internal_parse(TokenStream(contents)), indent=indent
-                )
-            else:
-                return json.dumps(self.internal_parse(TokenStream(contents)))
-        except InvalidSyntax as error:
-            raise SyntaxError(error.format("src"))
+        if indent:
+            return json.dumps(
+                self.internal_parse(TokenStream(contents)), indent=indent
+            )
+        
+        return json.dumps(self.internal_parse(TokenStream(contents)))
 
     def internal_parse(self, stream: TokenStream) -> list:
         """

--- a/allay/parser.py
+++ b/allay/parser.py
@@ -26,7 +26,7 @@ class Parser:
 
             return json.dumps(self.internal_parse(TokenStream(contents)))
         except InvalidSyntax as error:
-            raise InvalidSyntax(error)
+            raise InvalidSyntax(error.format("src"))
 
     def internal_parse(self, stream: TokenStream) -> list:
         """

--- a/allay/parser.py
+++ b/allay/parser.py
@@ -18,12 +18,15 @@ class Parser:
         Returns:
             str: The text-component
         """
-        if indent:
-            return json.dumps(
-                self.internal_parse(TokenStream(contents)), indent=indent
-            )
-        
-        return json.dumps(self.internal_parse(TokenStream(contents)))
+        try:
+            if indent:
+                return json.dumps(
+                    self.internal_parse(TokenStream(contents)), indent=indent
+                )
+
+            return json.dumps(self.internal_parse(TokenStream(contents)))
+        except InvalidSyntax as error:
+            raise InvalidSyntax(error)
 
     def internal_parse(self, stream: TokenStream) -> list:
         """

--- a/allay/plugin.py
+++ b/allay/plugin.py
@@ -5,25 +5,19 @@ from beet.contrib.messages import Message
 from beet.library.base import NamespaceFile
 from beet.library.data_pack import DataPack
 
-from tokenstream import InvalidSyntax
-
-from functools import cached_property
-
 from .parser import Parser
+
 
 class AllayMessage(TextFile, NamespaceFile):
     scope = ("messages",)
     extension = ".allay"
 
-    @cached_property
-    def parser(self) -> Parser:
-        return Parser()
-
     def bind(self, pack: DataPack, path: str):
-        json = self.parser.parse(self.text)
+        json = Parser().parse(self.text)
         pack[path] = Message(json)
 
         raise Drop()
+
 
 def beet_default(ctx: Context):
     ctx.data.extend_namespace.append(AllayMessage)

--- a/allay/plugin.py
+++ b/allay/plugin.py
@@ -1,0 +1,29 @@
+from beet import Context
+from beet.core.container import Drop
+from beet.core.file import TextFile
+from beet.contrib.messages import Message
+from beet.library.base import NamespaceFile
+from beet.library.data_pack import DataPack
+
+from tokenstream import InvalidSyntax
+
+from functools import cached_property
+
+from .parser import Parser
+
+class AllayMessage(TextFile, NamespaceFile):
+    scope = ("messages",)
+    extension = ".allay"
+
+    @cached_property
+    def parser(self) -> Parser:
+        return Parser()
+
+    def bind(self, pack: DataPack, path: str):
+        json = self.parser.parse(self.text)
+        pack[path] = Message(json)
+
+        raise Drop()
+
+def beet_default(ctx: Context):
+    ctx.data.extend_namespace.append(AllayMessage)

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.9',
+    python_requires=">=3.9",
 )


### PR DESCRIPTION
Added `beet` plugin functionality! `.allay` files in the `messages` resource namespace can be used in the same fashion as `beet.contrib.messages`

Also, automagically. `@allay_message` directive will function in the same fashion.

I also changed ur SyntaxError -> InvalidError and added an `__all__`. 