### PR TITLE
Feature: beet plugin template / pattern support

### DIFF
--- a/allay/parser.py
+++ b/allay/parser.py
@@ -327,15 +327,16 @@ class Parser:
                         raise InvalidSyntax(f"Unknown template '{q}'")
 
                     args = self.parse_template_args(stream)
-                    if args:
-                        # Turn the template into a string so we can use replace on it
-                        template_value = json.dumps(self.templates[q])
-                        # Replace all the tokens
-                        for index, arg in enumerate(args):
-                            template_value = template_value.replace(f"%{index}", arg)
 
-                        # Convert it back into a dictionary
-                        standalone_contents = json.loads(template_value)
+                    # Turn the template into a string so we can use replace on it
+                    template_value = json.dumps(self.templates[q])
+
+                    # Replace all the tokens
+                    for index, arg in enumerate(args):
+                        template_value = template_value.replace(f"%{index}", arg)
+
+                    # Convert it back into a dictionary
+                    standalone_contents = json.loads(template_value)
 
                 else:
                     standalone_contents = self.parse_non_template_standalone(stream)

--- a/allay/plugin.py
+++ b/allay/plugin.py
@@ -27,9 +27,9 @@ class AllayMessage(TextFile, NamespaceFile):
 
 def register_pattern(name: str, raw: Union[JsonDict, str]):
     if isinstance(raw, str):
-        raw = json.loads(parser.parse(raw))
-
-    parser.patterns[f"@{name}"] = raw
+        raw = json.loads(parser.parse(f'@{name} = {raw}\n#ALLAYDEFS\n'))
+    else:
+        parser.patterns[f"@{name}"] = raw
 
 
 def register_template(name: str, raw: Union[JsonDict, str]):

--- a/allay/plugin.py
+++ b/allay/plugin.py
@@ -1,11 +1,17 @@
+import json
+from typing import Union, cast
+
 from beet import Context
+from beet.contrib.messages import Message
 from beet.core.container import Drop
 from beet.core.file import TextFile
-from beet.contrib.messages import Message
+from beet.core.utils import JsonDict
 from beet.library.base import NamespaceFile
 from beet.library.data_pack import DataPack
 
 from .parser import Parser
+
+parser = Parser()
 
 
 class AllayMessage(TextFile, NamespaceFile):
@@ -13,11 +19,34 @@ class AllayMessage(TextFile, NamespaceFile):
     extension = ".allay"
 
     def bind(self, pack: DataPack, path: str):
-        json = Parser().parse(self.text)
+        json = parser.parse(self.text)
         pack[path] = Message(json)
 
         raise Drop()
 
 
+def register_pattern(name: str, raw: Union[JsonDict, str]):
+    if isinstance(raw, str):
+        raw = json.loads(parser.parse(raw))
+
+    parser.patterns[f"@{name}"] = raw
+
+
+def register_template(name: str, raw: Union[JsonDict, str]):
+    if isinstance(raw, str):
+        raw = json.loads(parser.parse(raw))
+
+    parser.templates[f"${name}"] = raw
+
+
 def beet_default(ctx: Context):
+    if config := ctx.meta.get("allay", cast(JsonDict, {})):
+        if patterns := config.get("patterns", cast(JsonDict, {})):
+            for name, pattern in patterns.items():
+                register_pattern(name, pattern)
+
+        if templates := config.get("templates", cast(JsonDict, {})):
+            for name, template in templates.items():
+                register_template(name, template)
+
     ctx.data.extend_namespace.append(AllayMessage)


### PR DESCRIPTION
Main feature is with the beet plugin. Allows templates and patterns to function properly by making the Parser a field inside the plugin.

#ALLAYDEFS will now update the templates and patterns and can be used across a beet project. 
Alternatively, there is also config support to define your patterns and templates in your config file. This is nice for those messing with sub-pipelines and manually overriding the config temporarily to be able to load their templates as they please.

Alongside this feature, there is another bug fix that was needed for templates to be operational. The template feature no longer requires arguments to function. This was actually a single line removal of the `if args` line since the enumeration of arguments will only occur if there are args to enumerate! 

Let me know if you have any questions. I ran your tests locally (I had to temporarily edit the file to read the local file since your pathfinding for the test file didn't work for me). I also tested your template and pattern example from discord alongside an example with PlayerDB.